### PR TITLE
Added a bind mount for atrust data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 ### 图形界面版 aTrust（amd64、arm64、mips64el 架构）
 
 1. [安装Docker并运行](https://docs.docker.com/get-docker/)；
-2. 在终端输入： `docker run --rm --device /dev/net/tun --cap-add NET_ADMIN -ti -e PASSWORD=xxxx -e URLWIN=1 -v $HOME/.atrust-data:/root -p 127.0.0.1:5901:5901 -p 127.0.0.1:1080:1080 -p 127.0.0.1:8888:8888 -p 127.0.0.1:54631:54631 hagb/docker-atrust`；
+2. 在终端输入： `docker run --rm --device /dev/net/tun --cap-add NET_ADMIN -ti -e PASSWORD=xxxx -e URLWIN=1 -v $HOME/.atrust-data/root:/root -v $HOME/.atrust-data/usr/share/sangfor/.aTrust:/usr/share/sangfor/.aTrust  -p 127.0.0.1:5901:5901 -p 127.0.0.1:1080:1080 -p 127.0.0.1:8888:8888 -p 127.0.0.1:54631:54631 hagb/docker-atrust`；
 3. 使用vnc客户端连接vnc， 地址：127.0.0.1，端口: 5901, 密码 xxxx；
 4. 成功连上后你应该能看到 aTrust 的登录窗口；若需要 web 登录，在宿主机的浏览器打开 aTrust 弹出的网址网址登录即可。
 


### PR DESCRIPTION
Atrust stores some extra data (eg. connect URL) at `/usr/share/sangfor/.aTrust` in additional to `/root`. Added this bind mount let Atrust remember that url (and maybe some extra info)