### PR TITLE
Fix the segmentation fault when pinging url

### DIFF
--- a/docker-root/usr/local/bin/start.sh
+++ b/docker-root/usr/local/bin/start.sh
@@ -186,7 +186,7 @@ keep_pinging() {
 # 部分服务器禁ping，用wget一个网页的url代替
 keep_pinging_url() {
 	[ -n "$PING_ADDR_URL" ] && while sleep $PING_INTERVAL; do
-		busybox wget -q -T 10 --spider "$PING_ADDR_URL"
+		timeout 10 busybox wget -q --spider "$PING_ADDR_URL" 2>/dev/null
 	done &
 }
 


### PR DESCRIPTION
Use `timeout` command instead of `-T` argument of busybox wget to limit the time used to ping url. `CONFIG_FEATURE_WGET_TIMEOUT` (`-T`) is not enabled in Debian package `busybox`<1.36.1-5 [^1]. As a result, `-T` of `busybox wget` in our current busybox package (1:1.35.0-4+b3) causes segmentation fault .

[^1]: https://salsa.debian.org/installer-team/busybox/-/commit/fd85f31f98a5316289f2de108e377d22345e0869

fix https://github.com/docker-easyconnect/docker-easyconnect/pull/367#issuecomment-2228939538