### PR TITLE
修复捕获信号

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ ENV PING_INTERVAL=1800
 
 VOLUME /root/ /usr/share/sangfor/EasyConnect/resources/logs/
 
-CMD start.sh
+CMD ["start.sh"]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -59,4 +59,4 @@ ENV PING_INTERVAL=1800
 
 VOLUME /root/ /usr/share/sangfor/EasyConnect/resources/logs/
 
-CMD start.sh
+CMD ["start.sh"]

--- a/Dockerfile.vncless
+++ b/Dockerfile.vncless
@@ -41,4 +41,4 @@ ENV PING_INTERVAL=1800
 
 VOLUME /root/ /usr/share/sangfor/EasyConnect/resources/logs/
 
-CMD ["bash", "-c", "TYPE=x11 start.sh"]
+CMD ["env", "TYPE=x11", "start.sh"]

--- a/Dockerfile.vncless
+++ b/Dockerfile.vncless
@@ -41,4 +41,4 @@ ENV PING_INTERVAL=1800
 
 VOLUME /root/ /usr/share/sangfor/EasyConnect/resources/logs/
 
-CMD TYPE=x11 start.sh
+CMD ["bash", "-c", "TYPE=x11 start.sh"]


### PR DESCRIPTION
解决问题
* `docker stop` 无法处理信号，只能[超时后强行杀死容器](https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop)。
* `trap` 不工作，无法调用 `sync_ec2volume` 同步配置。

方法来自：https://stackoverflow.com/a/46057188/10188914