### PR TITLE
Update README.md to introduce aTrustLogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 1. [安装Docker并运行](https://docs.docker.com/get-docker/)；
 2. 在终端输入： `docker run --rm --device /dev/net/tun --cap-add NET_ADMIN -ti -e PASSWORD=xxxx -e URLWIN=1 -v $HOME/.atrust-data:/root -p 127.0.0.1:5901:5901 -p 127.0.0.1:1080:1080 -p 127.0.0.1:8888:8888 -p 127.0.0.1:54631:54631 --sysctl net.ipv4.conf.default.route_localnet=1 hagb/docker-atrust`；
 3. 使用vnc客户端连接vnc， 地址：127.0.0.1，端口: 5901, 密码 xxxx；
-4. 成功连上后你应该能看到 aTrust 的登录窗口；若需要 web 登录，在宿主机的浏览器打开 aTrust 弹出的网址网址登录即可。
+4. 成功连上后你应该能看到 aTrust 的登录窗口；若需要 web 登录，在宿主机的浏览器打开 aTrust 弹出的网址网址登录即可；若需要无人值守的自动化登录和保活，请[参见此处](https://github.com/kenvix/aTrustLogin)。
 
 
 ## 拉取


### PR DESCRIPTION
此提交修改README.md，添加了一条到基于本项目的分支项目 aTrustLogin 的链接，**以期帮助那些有自动化登录需求的人**。

不将此项目直接合并到主线，主要是基于以下考虑：

- aTrustLogin 的 Docker 镜像添加了大量重量型依赖组件，导致镜像体积直接膨胀一倍有余
- aTrustLogin 并不强依赖 Docker 和本项目，它也能直接在各种平台直接使用。
- CI能保证主线的更改自动合并到下游