### PR TITLE
add atrust-2.5.10.40 build args

### DIFF
--- a/build-args/atrust-2.5.10.40-amd64.txt
+++ b/build-args/atrust-2.5.10.40-amd64.txt
@@ -1,0 +1,1 @@
+--build-arg VPN_URL=https://atrustcdn.sangfor.com/standard/linux/2.5.10.40/uos/amd64/aTrustInstaller_amd64.deb --build-arg VPN_TYPE=ATRUST

--- a/build-args/atrust-2.5.10.40-arm64.txt
+++ b/build-args/atrust-2.5.10.40-arm64.txt
@@ -1,0 +1,1 @@
+--build-arg VPN_URL=https://atrustcdn.sangfor.com/standard/linux/2.5.10.40/uos/arm64/aTrustInstaller_arm64.deb --build-arg VPN_TYPE=ATRUST

--- a/build-args/atrust-2.5.10.40-mips64le.txt
+++ b/build-args/atrust-2.5.10.40-mips64le.txt
@@ -1,0 +1,1 @@
+--build-arg VPN_URL=https://atrustcdn.sangfor.com/standard/linux/2.5.10.40/uos/mips64el/aTrustInstaller_mips64el.deb --build-arg VPN_TYPE=ATRUST

--- a/build-args/atrust-amd64.txt
+++ b/build-args/atrust-amd64.txt
@@ -1,1 +1,1 @@
-atrust-2.4.10.50-amd64.txt
+atrust-2.5.10.40-amd64.txt

--- a/build-args/atrust-arm64.txt
+++ b/build-args/atrust-arm64.txt
@@ -1,1 +1,1 @@
-atrust-2.4.10.50-arm64.txt
+atrust-2.5.10.40-arm64.txt

--- a/build-args/atrust-mips64le_.txt
+++ b/build-args/atrust-mips64le_.txt
@@ -1,1 +1,1 @@
-atrust-2.4.10.50-mips64le.txt
+atrust-2.5.10.40-mips64le.txt


### PR DESCRIPTION
Updates the VPN build configuration files to use the latest ATRUST installer version 2.5.10.40 across all architectures (amd64, arm64, and mips64le).

The references to the previous version (2.4.10.50) have been replaced, and new build arguments for the updated installer URLs have been added.
