### PR TITLE
fix: aTrust SOCKS 代理连接失败问题

### DIFF
--- a/docker-root/etc/danted.conf.sample
+++ b/docker-root/etc/danted.conf.sample
@@ -10,7 +10,7 @@ external.rotation: route
 
 #server identities (not needed on solaris)
 user.privileged: root
-user.notprivileged: socks
+user.notprivileged: root
 #user.libwrap: libwrap
 
 #authentication methods

--- a/docker-root/usr/local/bin/vpn-config.sh
+++ b/docker-root/usr/local/bin/vpn-config.sh
@@ -75,6 +75,9 @@ case "$_VPN_TYPE" in
 			# - 先尝试 getlogin_r，若获取到 root 则失败，服务无法启动（这是 podman 上无法启动服务的原因）；
 			# - 若获取不到则，使用 loginctl 等工具（已经过 hook，可以提供普通用户供 aTrust 使用，此为原本 docker 上的行为）。
 			# 此处使用 LD_PRELOAD 来让 getlogin_r 直接返回该普通用户，从而使 podman 也能够正常启动服务。
+			# 添加 uid 策略路由，使 sangfor(uid=1234) 进程的流量走原始路由表（table 2），
+			# 绕过 VPN 隧道，避免 aTrustCore 连接 VPN 服务器时被 xtunnel 捕获导致 SSL 错误循环。
+			ip rule add uidrange 1234-1234 table 2 2>/dev/null || true
 			FAKE_LOGIN=sangfor LD_PRELOAD=/usr/local/lib/fake-getlogin.so LD_LIBRARY_PATH="$VPN_ROOT:$VPN_BIN:${LD_LIBRARY_PATH}" \
 				fake-hwaddr-run $VPN_BIN/aTrustAgent --plugin plugin-daemon --plugin-cmd \| >/dev/null &
 		}


### PR DESCRIPTION
问题1：danted worker 进程以 uid=997(socks) 运行，xtunnel 通过 uid+inode 查找进程时找不到，导致所有经过 utun7 的 SOCKS 连接被丢弃。
修复：将 danted.conf.sample 中 user.notprivileged 改为 root。

问题2：aTrustCore (sangfor, uid=1234) 连接 VPN 服务器时，DNS 返回虚拟 IP (198.18.x.x)，流量进入 utun7 后被 xtunnel 拦截，造成 SSL 循环失败。 修复：在 vpn_daemon() 中添加策略路由，使 uid=1234 的流量走原始路由表
(table 2 / eth0)，绕过 VPN 隧道。